### PR TITLE
Fix contact without any relation

### DIFF
--- a/app/views/players/show.haml
+++ b/app/views/players/show.haml
@@ -20,9 +20,9 @@
     = link_to edit_address_path(@player.address), class: 'default-button' do
       = edit_icon
       Addresse ändern
-    -# = link_to edit_contact_path(@player.contact), class: 'default-button' do
-    -#   = edit_icon
-    -#   Kontaktdaten bearbeiten
+    = link_to edit_contact_path(@player.contact), class: 'default-button' do
+      = edit_icon
+      Kontaktdaten bearbeiten
 
 .halfs
   .half
@@ -33,5 +33,5 @@
 .halfs
   .half
     = render 'addresses/details', address: @player.address
-  -# .half
-  -#   = render 'contacts/details', contact: @player.contact
+  .half
+    = render 'contacts/details', contact: @player.contact

--- a/db/migrate/20160901010201_bind_contacts_to_members_via_email.rb
+++ b/db/migrate/20160901010201_bind_contacts_to_members_via_email.rb
@@ -1,0 +1,9 @@
+class BindContactsToMembersViaEmail < ActiveRecord::Migration[5.0]
+  def change
+     Contact.all.each do |contact|
+      username = contact.club_email.split('@').first
+      user = User.find_by(username: username)
+      contact.update!(member_id: user.member.id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830201814) do
+ActiveRecord::Schema.define(version: 20160901010201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
After migration contacts were without any relation
to member. Because the migration were written in 
ruby code and the belongs_to was written after 
migration without running them again with the 
backup from the production.
This commit searches a member based on the 
username from user by the name of the club_email. 
This migration does not effect any rollback 
action. If a rollback is triggered nothing will 
be change. This migration should be deleted after 
it finished because it will overwrite the member 
id on second run.